### PR TITLE
Update ibm cloud documentation

### DIFF
--- a/site/content/docs/main/csi-snapshot-data-movement.md
+++ b/site/content/docs/main/csi-snapshot-data-movement.md
@@ -121,6 +121,24 @@ oc annotate namespace <velero namespace> openshift.io/node-selector=""
 oc create -n <velero namespace> -f ds.yaml
 ```
 
+**OpenShift on IBM Cloud**
+
+
+Update the host path for volumes in the node-agent DaemonSet in the Velero namespace from `/var/lib/kubelet/pods` to
+`/var/data/kubelet/pods`.
+
+```yaml
+hostPath:
+  path: /var/lib/kubelet/pods
+```
+
+to
+
+```yaml
+hostPath:
+  path: /var/data/kubet/pods
+```
+
 **VMware Tanzu Kubernetes Grid Integrated Edition (formerly VMware Enterprise PKS)**  
 
 You need to enable the `Allow Privileged` option in your plan configuration so that Velero is able to mount the hostpath.  

--- a/site/content/docs/v1.14/csi-snapshot-data-movement.md
+++ b/site/content/docs/v1.14/csi-snapshot-data-movement.md
@@ -121,7 +121,7 @@ oc annotate namespace <velero namespace> openshift.io/node-selector=""
 oc create -n <velero namespace> -f ds.yaml
 ```
 
-***Openshift on IBM Cloud***
+**Openshift on IBM Cloud**
 
 Update the host path for volumes in the node-agent DaemonSet in the Velero namespace from `/var/lib/kubelet/pods` to
 `/var/data/kubelet/pods`.

--- a/site/content/docs/v1.14/csi-snapshot-data-movement.md
+++ b/site/content/docs/v1.14/csi-snapshot-data-movement.md
@@ -121,6 +121,24 @@ oc annotate namespace <velero namespace> openshift.io/node-selector=""
 oc create -n <velero namespace> -f ds.yaml
 ```
 
+***Openshift on IBM Cloud***
+
+Update the host path for volumes in the node-agent DaemonSet in the Velero namespace from `/var/lib/kubelet/pods` to
+`/var/data/kubelet/pods`.
+
+```yaml
+hostPath:
+  path: /var/lib/kubelet/pods
+```
+
+to
+
+```yaml
+hostPath:
+  path: /var/data/kubet/pods
+```
+
+
 **VMware Tanzu Kubernetes Grid Integrated Edition (formerly VMware Enterprise PKS)**  
 
 You need to enable the `Allow Privileged` option in your plan configuration so that Velero is able to mount the hostpath.  

--- a/site/content/docs/v1.14/csi-snapshot-data-movement.md
+++ b/site/content/docs/v1.14/csi-snapshot-data-movement.md
@@ -121,7 +121,7 @@ oc annotate namespace <velero namespace> openshift.io/node-selector=""
 oc create -n <velero namespace> -f ds.yaml
 ```
 
-**Openshift on IBM Cloud**
+**OpenShift on IBM Cloud**
 
 Update the host path for volumes in the node-agent DaemonSet in the Velero namespace from `/var/lib/kubelet/pods` to
 `/var/data/kubelet/pods`.

--- a/site/content/docs/v1.14/csi-snapshot-data-movement.md
+++ b/site/content/docs/v1.14/csi-snapshot-data-movement.md
@@ -123,6 +123,7 @@ oc create -n <velero namespace> -f ds.yaml
 
 **OpenShift on IBM Cloud**
 
+
 Update the host path for volumes in the node-agent DaemonSet in the Velero namespace from `/var/lib/kubelet/pods` to
 `/var/data/kubelet/pods`.
 
@@ -137,7 +138,6 @@ to
 hostPath:
   path: /var/data/kubet/pods
 ```
-
 
 **VMware Tanzu Kubernetes Grid Integrated Edition (formerly VMware Enterprise PKS)**  
 


### PR DESCRIPTION
# Description

Update documentation to add customization for data movement for Openshift on IBM Cloud Environments.

Signed-off-by: Michael Fruchtman <msfrucht@us.ibm.com>

# Does your change fix a particular issue?
No code changes.

Required documentation for the data movement to work in Velero 1.13, 1.14 for OpenShift on IBM Cloud.

The default exposed host folders will cause the dataupload and datadownload based data movement to fail.

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
